### PR TITLE
Added "init_instance" event and prevented "init_instance_callback" option override.

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,3 +43,8 @@ export default{
 | toolbar2 | String | '' | Toolbar 2 of tinymce |
 | plugins | Array | `['advlist autolink lists link image charmap print preview hr anchor pagebreak','searchreplace wordcount visualblocks visualchars code fullscreen','insertdatetime media nonbreaking save table contextmenu directionality','template']` | plugins of tinymce you need to load |
 | other_options | Array | {} | other tinymce options. you can also override our initial options |
+
+## Events
+| Event | Parameters | Description |
+|----------|--------------|-------------|
+| init_instance | editor, Object | The tinymce editor's 'init_instance_callback' event |

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "vue-tinymce-editor",
-  "version": "1.4.4",
+  "version": "1.4.5",
   "description": "This a component provides easy use of tinymce for vue developers",
   "author": "Roozbeh Hajizadeh <hajizadeh.roozbeh@gmail.com>",
   "contributors": ["Grant Mooney <gamooney@mail.bradley.edu> (https://github.com/grantmooney)"],

--- a/package.json
+++ b/package.json
@@ -3,6 +3,7 @@
   "version": "1.4.4",
   "description": "This a component provides easy use of tinymce for vue developers",
   "author": "Roozbeh Hajizadeh <hajizadeh.roozbeh@gmail.com>",
+  "contributors": ["Grant Mooney <gamooney@mail.bradley.edu> (https://github.com/grantmooney)"],
   "private": false,
   "main": "./src/index.js",
   "scripts": {

--- a/src/components/TinymceVue.vue
+++ b/src/components/TinymceVue.vue
@@ -145,8 +145,6 @@
         beforeDestroy () {
             if (this.editor) {
                 this.editor.destroy();
-                // tinymce.execCommand("mceRemoveEditor", false, this.id);
-                // this.editor = null;
             }
         },
         watch: {
@@ -158,11 +156,6 @@
                         this.content = newValue;
                 }
             }
-            // disabled: function(newValue) {
-            //     if (this.editor) {
-            //         this.editor.getBody().setAttribute('contenteditable', !newValue);
-            //     }
-            // }
         },
         methods: {
             init(){
@@ -188,7 +181,6 @@
                       editor.setContent(this.content);
                       this.$emit('input', this.content);                      
                       this.$emit('init_instance', editor);
-                      // editor.getBody().setAttribute('contenteditable', !this.disabled);
                     }
                 });
                 tinymce.init(options);

--- a/src/components/TinymceVue.vue
+++ b/src/components/TinymceVue.vue
@@ -167,6 +167,7 @@
                       editor.on('init', (e) => {
                           editor.setContent(this.content);
                           this.$emit('input', this.content);
+                          debugger;
                       });
                       this.$emit('init_instance', editor);
                     }

--- a/src/components/TinymceVue.vue
+++ b/src/components/TinymceVue.vue
@@ -59,6 +59,37 @@
     
     import 'tinymce/skins/lightgray/skin.min.css'
     import 'tinymce/skins/lightgray/content.min.css'
+    
+    // Object.assign polyfill
+    if (typeof Object.assign != 'function') {
+      // Must be writable: true, enumerable: false, configurable: true
+      Object.defineProperty(Object, "assign", {
+        value: function assign(target, varArgs) { // .length of function is 2
+          'use strict';
+          if (target == null) { // TypeError if undefined or null
+            throw new TypeError('Cannot convert undefined or null to object');
+          }
+
+          var to = Object(target);
+
+          for (var index = 1; index < arguments.length; index++) {
+            var nextSource = arguments[index];
+
+            if (nextSource != null) { // Skip over if undefined or null
+              for (var nextKey in nextSource) {
+                // Avoid bugs when hasOwnProperty is shadowed
+                if (Object.prototype.hasOwnProperty.call(nextSource, nextKey)) {
+                  to[nextKey] = nextSource[nextKey];
+                }
+              }
+            }
+          }
+          return to;
+        },
+        writable: true,
+        configurable: true
+      });
+    }
    
     export default {
         name: 'tinymce',
@@ -138,14 +169,6 @@
                 });
                 tinymce.init(options);
             },
-            concatAssciativeArrays(array1, array2){
-                if(array2.length === 0) return array1;
-                if(array1.length === 0) return array2;
-                let dest = [];
-                for ( let key in array1) dest[key] = array1[key];
-                for ( let key in array2) dest[key] = array2[key];
-                return dest;
-            },
             submitNewContent(){
                 this.isTyping = true;
                 if(this.checkerTimeout !== null)
@@ -159,8 +182,3 @@
         }
     }
 </script>
-
-<!-- Add "scoped" attribute to limit CSS to this component only -->
-<style scoped>
-
-</style>

--- a/src/components/TinymceVue.vue
+++ b/src/components/TinymceVue.vue
@@ -127,7 +127,11 @@
             this.init();  
         },
         beforeDestroy () {
-            this.editor.destroy();
+            if (this.editor) {
+                this.editor.destroy();
+                // tinymce.execCommand("mceRemoveEditor", false, this.id);
+                // this.editor = null;
+            }
         },
         watch: {
             value : function (newValue){

--- a/src/components/TinymceVue.vue
+++ b/src/components/TinymceVue.vue
@@ -164,11 +164,8 @@
                              this.submitNewContent();
                           }
                       });
-                      editor.on('init', (e) => {
-                          editor.setContent(this.content);
-                          this.$emit('input', this.content);
-                          debugger;
-                      });
+                      editor.setContent(this.content);
+                      this.$emit('input', this.content);                      
                       this.$emit('init_instance', editor);
                     }
                 });

--- a/src/components/TinymceVue.vue
+++ b/src/components/TinymceVue.vue
@@ -164,7 +164,7 @@
                           editor.setContent(this.content);
                           this.$emit('input', this.content);
                       });
-                      this.$emit('init', editor);
+                      this.$emit('init_instance', editor);
                     }
                 });
                 tinymce.init(options);

--- a/src/components/TinymceVue.vue
+++ b/src/components/TinymceVue.vue
@@ -128,9 +128,9 @@
         },
         beforeDestroy () {
             if (this.editor) {
-                this.editor.destroy();
-                // tinymce.execCommand("mceRemoveEditor", false, this.id);
-                // this.editor = null;
+                // this.editor.destroy();
+                tinymce.execCommand("mceRemoveEditor", false, this.id);
+                this.editor = null;
             }
         },
         watch: {

--- a/src/components/TinymceVue.vue
+++ b/src/components/TinymceVue.vue
@@ -110,29 +110,33 @@
         },
         methods: {
             init(){
-                let options = {
+                let options = Object.assign({
                     selector: '#' + this.id,
                     skin: false,
                     toolbar1: this.toolbar1,
                     toolbar2: this.toolbar2,
                     plugins: this.plugins,
+                  },
+                  this.other_options, 
+                  {
                     init_instance_callback : (editor) => {
-                        this.editor = editor;
-                        editor.on('KeyUp', (e) => {
-                           this.submitNewContent();
-                        });
-                        editor.on('Change', (e) => {
-                            if(this.editor.getContent() !== this.value){
-                               this.submitNewContent();
-                            }
-                        });
-                        editor.on('init', (e) => {
-                            editor.setContent(this.content);
-                            this.$emit('input', this.content);
-                        });
+                      this.editor = editor;
+                      editor.on('KeyUp', (e) => {
+                         this.submitNewContent();
+                      });
+                      editor.on('Change', (e) => {
+                          if(this.editor.getContent() !== this.value){
+                             this.submitNewContent();
+                          }
+                      });
+                      editor.on('init', (e) => {
+                          editor.setContent(this.content);
+                          this.$emit('input', this.content);
+                      });
+                      this.$emit('init', editor);
                     }
-                };
-                tinymce.init(this.concatAssciativeArrays(options, this.other_options));
+                });
+                tinymce.init(options);
             },
             concatAssciativeArrays(array1, array2){
                 if(array2.length === 0) return array1;

--- a/src/components/TinymceVue.vue
+++ b/src/components/TinymceVue.vue
@@ -1,8 +1,24 @@
 <template>
-  <div>
+  <div v-bind:disabled="disabled">
       <textarea :id="id">{{ content }}</textarea>
   </div>
 </template>
+
+<style scoped>
+    div[disabled] {
+        position: relative !important;
+    }
+    div[disabled]::after {
+        content:"";
+        display: block;
+        height: 100%;
+        position: absolute !important;
+        top: 0;
+        left: 0;
+        width: 100%;
+        background-color: rgba(255, 255, 255, .6);
+    }
+</style>
 
 <script>
    // Import TinyMCE
@@ -74,7 +90,6 @@
 
           for (var index = 1; index < arguments.length; index++) {
             var nextSource = arguments[index];
-
             if (nextSource != null) { // Skip over if undefined or null
               for (var nextKey in nextSource) {
                 // Avoid bugs when hasOwnProperty is shadowed
@@ -100,6 +115,7 @@
                 },
                 'htmlClass' : { default : '', type : String},
                 'value' : { default : '' },
+                'disabled': { default: false },
                 'plugins' : { default : function(){ 
                                     return [
                                         'advlist autolink lists link image charmap print preview hr anchor pagebreak',
@@ -128,9 +144,9 @@
         },
         beforeDestroy () {
             if (this.editor) {
-                // this.editor.destroy();
-                tinymce.execCommand("mceRemoveEditor", false, this.id);
-                this.editor = null;
+                this.editor.destroy();
+                // tinymce.execCommand("mceRemoveEditor", false, this.id);
+                // this.editor = null;
             }
         },
         watch: {
@@ -142,6 +158,11 @@
                         this.content = newValue;
                 }
             }
+            // disabled: function(newValue) {
+            //     if (this.editor) {
+            //         this.editor.getBody().setAttribute('contenteditable', !newValue);
+            //     }
+            // }
         },
         methods: {
             init(){
@@ -167,6 +188,7 @@
                       editor.setContent(this.content);
                       this.$emit('input', this.content);                      
                       this.$emit('init_instance', editor);
+                      // editor.getBody().setAttribute('contenteditable', !this.disabled);
                     }
                 });
                 tinymce.init(options);


### PR DESCRIPTION
Previously, overriding the "init_instance_callback" option caused the component to effectively break. Preventing the "init_instance_callback" override adding an "init_instance" event allows users to add editor instance listeners without breaking the component.